### PR TITLE
Use https for _baseUrl.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function SoundCloud (clientId) {
     this._events = {};
 
     this._clientId = clientId;
-    this._baseUrl = 'http://api.soundcloud.com';
+    this._baseUrl = 'https://api.soundcloud.com';
 
     this.playing = false;
     this.duration = 0;


### PR DESCRIPTION
Use https for base url to prevent "Mixed Content" error when using this module on a page served over https.